### PR TITLE
Correct Stop Sketch Button

### DIFF
--- a/Editor/SketchRunner.cs
+++ b/Editor/SketchRunner.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -15,21 +14,21 @@ namespace AIR.Sketch
 
         static SketchRunner()
         {
-            EditorApplication.playModeStateChanged += delegate(PlayModeStateChange change) {
+            EditorApplication.playModeStateChanged += change => {
                 var runningSketch = EditorPrefs.GetBool(RUNNING_SKETCH_KEY);
                 if (runningSketch && change == PlayModeStateChange.EnteredEditMode) {
                     EditorPrefs.SetBool(RUNNING_SKETCH_KEY, false);
                     var sceneNameBeforeSketch = EditorPrefs.GetString(SCENE_BEFORE_SKETCH_KEY);
-                    if (!string.IsNullOrEmpty(sceneNameBeforeSketch))
+                    if (!string.IsNullOrEmpty(sceneNameBeforeSketch)) {
                         EditorSceneManager.OpenScene(sceneNameBeforeSketch);
+                        EditorPrefs.SetString(SCENE_BEFORE_SKETCH_KEY, string.Empty);
+                    }
                 }
             };
         }
 
         public static void RunSketch(Type sketchType)
         {
-            // TODO: Check sketch is monobehaviour
-
             EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
             var currentScene = SceneManager.GetActiveScene();
             EditorPrefs.SetString(SCENE_BEFORE_SKETCH_KEY, currentScene.path);
@@ -44,6 +43,12 @@ namespace AIR.Sketch
             var sketchGo = new GameObject(sketchType.Name);
             sketchGo.AddComponent<SketchServiceInstaller>();
             sketchGo.AddComponent(sketchType);
+        }
+
+        public static void SketchFinished()
+        {
+            EditorPrefs.SetString(SCENE_BEFORE_SKETCH_KEY, string.Empty);
+            EditorPrefs.SetString(SketchRunnerWindow.RUNNING_SKETCH_NAME, string.Empty);
         }
     }
 }

--- a/Editor/SketchRunnerWindow.cs
+++ b/Editor/SketchRunnerWindow.cs
@@ -13,7 +13,7 @@ namespace AIR.Sketch
         private Texture2D _pinnedIcon = null;
 
         private const int BUTTON_WIDTH = 25;
-        private const string RUNNING_SKETCH_NAME = "RUNNING_SKETCH_NAME";
+        public const string RUNNING_SKETCH_NAME = "RUNNING_SKETCH_NAME";
 
         private List<SketchAssembly> _sketches = new List<SketchAssembly>();
         private Vector2 _scrollPosition = Vector2.zero;
@@ -39,18 +39,15 @@ namespace AIR.Sketch
                 if (cancel)
                     EditorApplication.ExitPlaymode();
             } else {
-                // _scrollPosition = GUILayout.BeginScrollView(_scrollPosition);
                 OnDrawSketchesFixtures();
-                // GUILayout.EndScrollView();
             }
         }
 
         private void OnInspectorUpdate()
         {
             if (_selectedSketch != null) {
-                // TODO: Resolve and inject dependencies.
-                SketchRunner.RunSketch(_selectedSketch);
                 EditorPrefs.SetString(RUNNING_SKETCH_NAME, _selectedSketch.Name);
+                SketchRunner.RunSketch(_selectedSketch);
                 _selectedSketch = null;
             }
         }

--- a/Editor/SketchServiceInstaller.cs
+++ b/Editor/SketchServiceInstaller.cs
@@ -10,9 +10,12 @@ namespace AIR.Sketch
     [RequireComponent(typeof(FlumeServiceContainer))]
     public class SketchServiceInstaller : MonoBehaviour
     {
-        void Awake() => gameObject
+
+        private void Awake() => gameObject
             .GetComponent<FlumeServiceContainer>()
             .OnContainerReady += InstallServices;
+
+        private void OnDestroy() => SketchRunner.SketchFinished();
 
         private void InstallServices(FlumeServiceContainer container)
         {


### PR DESCRIPTION
By saving and confirming that we are in fact in playmode and within the sketch scene, the SketchRunnerWindow can now correctly report stop sketch vs cannot play as already in playmode.