### PR TITLE
Merge bug/12 into dev: Use Null-conditional during sketch search filtering

### DIFF
--- a/Editor/SketchRunnerWindow.cs
+++ b/Editor/SketchRunnerWindow.cs
@@ -88,8 +88,8 @@ namespace AIR.Sketch
 
             var filteredSketches = _sketches
                 .SelectMany(x => x.Fixtures)
-                .Where(x => x.FullName.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
-                            x.Description.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >= 0);
+                .Where(x => x.FullName?.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
+                            x.Description?.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >= 0);
 
             _scrollPosition = GUILayout.BeginScrollView(_scrollPosition);
             GUILayout.BeginVertical(EditorStyles.helpBox);


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>' -->
## Summary
<!-- A clear and concise summary (1-2 sentences) of changes made. -->
When part of a sketch fixture info is null during a search/filter it would throw preventing the sketch ui from drawing.

## Closes
<!-- add task issue links to close here, e.g. #123 -->
closes #12 

## Details
<!-- A more in-depth listing of changes made. -->
Descriptions in particular are likely to be null.