### PR TITLE
Merge 8_non-monobeh-sketches into develop: Add support for ScriptableObject based Sketchs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Runtime asm, containing all attributes.
+- Sketches can now inherit from ScriptableObject.
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Error when a sketch search resulted in no results.
+- SketchRunner correctly returns to the previous scene when stopping.
 
 ## [0.0.1]
 

--- a/Editor/PinnedSketchTracker.cs
+++ b/Editor/PinnedSketchTracker.cs
@@ -1,5 +1,3 @@
-// Copyright (c) AIR Pty Ltd. All rights reserved.
-
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;

--- a/Editor/SketchAssetOpener.cs
+++ b/Editor/SketchAssetOpener.cs
@@ -9,7 +9,8 @@ namespace AIR.Sketch
 
         public static void OpenSketch(Type sketchFixture)
         {
-            foreach (var asset in AssetDatabase.GetAllAssetPaths()) {
+            foreach (var asset in AssetDatabase.GetAllAssetPaths())
+            {
                 if (!asset.EndsWith(sketchFixture.Name + CSHARP_EXT)) continue;
 
                 var csharpAsset = (MonoScript)AssetDatabase.LoadAssetAtPath(asset, typeof(MonoScript));

--- a/Editor/SketchRunner.cs
+++ b/Editor/SketchRunner.cs
@@ -22,7 +22,7 @@ namespace AIR.Sketch
                 var runningSketch = EditorPrefs.GetBool(RUNNING_SKETCH_KEY);
                 if (!runningSketch)
                     return;
-                
+
                 if (change == PlayModeStateChange.EnteredEditMode)
                 {
                     EditorPrefs.SetBool(RUNNING_SKETCH_KEY, false);
@@ -35,7 +35,7 @@ namespace AIR.Sketch
                     EditorPrefs.SetString(SCENE_BEFORE_SKETCH_KEY, string.Empty);
                     EditorPrefs.SetString(SketchRunnerWindow.RUNNING_SKETCH_NAME, string.Empty);
                 }
-                else if(change == PlayModeStateChange.EnteredPlayMode)
+                else if (change == PlayModeStateChange.EnteredPlayMode)
                 {
                     var fullTypeName = EditorPrefs.GetString(SKETCH_FULL_TYPE_NAME_KEY);
                     var asmName = EditorPrefs.GetString(SKETCH_ASSEMBLY_NAME_KEY);

--- a/Editor/SketchRunnerWindow.cs
+++ b/Editor/SketchRunnerWindow.cs
@@ -32,7 +32,8 @@ namespace AIR.Sketch
 
         private void OnGUI()
         {
-            if (Application.isPlaying) {
+            if (Application.isPlaying)
+            {
                 var sketchName = EditorPrefs.GetString(RUNNING_SKETCH_NAME);
                 var cancel = GUILayout.Button(
                     "Stop " + sketchName,
@@ -40,14 +41,17 @@ namespace AIR.Sketch
                     GUILayout.ExpandHeight(true));
                 if (cancel)
                     EditorApplication.ExitPlaymode();
-            } else {
+            }
+            else
+            {
                 OnDrawSketchesFixtures();
             }
         }
 
         private void OnInspectorUpdate()
         {
-            if (_selectedSketch != null) {
+            if (_selectedSketch != null)
+            {
                 EditorPrefs.SetString(RUNNING_SKETCH_NAME, _selectedSketch.Name);
                 SketchRunner.RunSketch(_selectedSketch);
                 _selectedSketch = null;
@@ -119,9 +123,12 @@ namespace AIR.Sketch
                 PinnedSketchTracker.ClearPinned();
             GUILayout.EndHorizontal();
             HorizontalLine();
-            foreach (var sketchAssembly in _sketches) {
-                foreach (var sketchFixure in sketchAssembly.Fixtures) {
-                    if (PinnedSketchTracker.IsPinned(sketchFixure.FullName)) {
+            foreach (var sketchAssembly in _sketches)
+            {
+                foreach (var sketchFixure in sketchAssembly.Fixtures)
+                {
+                    if (PinnedSketchTracker.IsPinned(sketchFixure.FullName))
+                    {
                         DrawSketchRunnerGUIItem(sketchFixure);
                     }
                 }
@@ -194,12 +201,15 @@ namespace AIR.Sketch
             GUILayout.EndVertical();
 
             var pinButtonSkin = new GUIStyle(GUI.skin.label);
-            if (PinnedSketchTracker.IsPinned(sketchFixture.FullName)) {
+            if (PinnedSketchTracker.IsPinned(sketchFixture.FullName))
+            {
                 var unpinnedIconContent = new GUIContent(_pinnedIcon);
                 var unpinClicked = GUILayout.Button(unpinnedIconContent, pinButtonSkin, buttonHeight, openButtonWidth);
                 if (unpinClicked)
                     PinnedSketchTracker.UnpinSketch(sketchFixture.FullName);
-            } else {
+            }
+            else
+            {
                 var pinnedIconContent = new GUIContent(_unpinnedIcon);
                 var pinClicked = GUILayout.Button(pinnedIconContent, pinButtonSkin, buttonHeight, openButtonWidth);
                 if (pinClicked)
@@ -212,16 +222,16 @@ namespace AIR.Sketch
         private void Awake()
         {
             var playIconPath = "Packages/com.air.sketch/Editor/PlayIcon.png";
-            _playIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(playIconPath, typeof(Texture2D));
+            _playIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(playIconPath, typeof(Texture2D));
 
             var editIconPath = "Packages/com.air.sketch/Editor/EditIcon.png";
-            _editIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(editIconPath, typeof(Texture2D));
+            _editIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(editIconPath, typeof(Texture2D));
 
             var unpinnedIconPath = "Packages/com.air.sketch/Editor/UnpinnedIcon.png";
-            _unpinnedIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(unpinnedIconPath, typeof(Texture2D));
+            _unpinnedIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(unpinnedIconPath, typeof(Texture2D));
 
             var pinnedIconPath = "Packages/com.air.sketch/Editor/PinnedIcon.png";
-            _pinnedIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(pinnedIconPath, typeof(Texture2D));
+            _pinnedIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(pinnedIconPath, typeof(Texture2D));
 
             RefreshSketchList();
         }
@@ -235,17 +245,19 @@ namespace AIR.Sketch
         private void RefreshSketchList()
         {
             _sketches.Clear();
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
                 var assemblyName = assembly.GetName().Name;
                 if (!assemblyName.EndsWith(".Sketches")) continue;
                 var fixtures = new List<SketchFixture>();
-                foreach (var type in assembly.GetTypes()) {
+                foreach (var type in assembly.GetTypes())
+                {
                     if (type.IsAbstract) continue;
-                    var sketchFixtureAttribute = (SketchFixtureAttribute) Attribute
+                    var sketchFixtureAttribute = (SketchFixtureAttribute)Attribute
                         .GetCustomAttribute(type, typeof(SketchFixtureAttribute));
                     if (sketchFixtureAttribute == null) continue;
 
-                    var descriptionAttribute = (SketchDescriptionAttribute) Attribute
+                    var descriptionAttribute = (SketchDescriptionAttribute)Attribute
                         .GetCustomAttribute(type, typeof(SketchDescriptionAttribute));
                     var description = descriptionAttribute?.Description;
 

--- a/Editor/SketchServiceInstaller.cs
+++ b/Editor/SketchServiceInstaller.cs
@@ -15,8 +15,6 @@ namespace AIR.Sketch
             .GetComponent<FlumeServiceContainer>()
             .OnContainerReady += InstallServices;
 
-        private void OnDestroy() => SketchRunner.SketchFinished();
-
         private void InstallServices(FlumeServiceContainer container)
         {
             var dependencies = ResolveDependencies();

--- a/README.md
+++ b/README.md
@@ -7,9 +7,18 @@ AIR's sketch framework allows you to build and interactively run small code snip
 ## Creating Sketches
 
 ### Prerequisites
-For the Unity Editor to recognise sketches, they must satisfy two requirements:
+For the Unity Editor to recognise and run sketches, they must:
 1. The sketch class must exists inside of an assembly with a name ending in ".Sketches". eg `Example.Sketches.asmdef`.
 2. The sketch class must have the `[SketchFixture]` attribute.
+3. Inherit from MonoBehaviour or ScriptableObject.
+
+### Running
+
+SketchRunner puts the game into playmode in an empty scene with the Sketch in it. If you have inherited from MonoBehaviour, this acts as normal. If you have inherited from ScriptableObject, SketchFixtureRunner will attempt to invoke a number of default Unity Messages. Such as `Start`, `Update`, `OnGUI`, `OnDrawGizmos`, `OnDestroy`, and more.
+
+### Data
+
+Sketches inherit from UnityEngine.Object so that you can assign default editor values in the MonoScript asset importer.
 
 ### Adding Descriptions
 It is recommended that when creating a new sketch, you use the `[SketchDescription]` attribute on the class. Doing so provides developers more information about what the sketch is expected to demonstrate, and the text appears along with the test in in the sketch runner.

--- a/Runtime/SketchFixtureRunner.cs
+++ b/Runtime/SketchFixtureRunner.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace AIR.Sketch
+{
+    public class SketchFixtureRunner : MonoBehaviour
+    {
+        private Component _monobeh;
+        private ScriptableObject _so;
+
+#if UNITY_EDITOR
+        public void Awake()
+        {
+            UnityEditor.EditorApplication.playModeStateChanged += EditorApplication_playModeStateChanged;
+        }
+
+        private void EditorApplication_playModeStateChanged(UnityEditor.PlayModeStateChange obj)
+        {
+            if (obj == UnityEditor.PlayModeStateChange.ExitingPlayMode)
+            {
+                DestroyImmediate(gameObject);
+                UnityEditor.EditorApplication.playModeStateChanged -= EditorApplication_playModeStateChanged;
+            }
+        }
+#endif
+
+        public void RunSketchFixture(Type type)
+        {
+            if (type.IsSubclassOf(typeof(MonoBehaviour)))
+            {
+                _monobeh = gameObject.AddComponent(type);
+            }
+            else if (type.IsSubclassOf(typeof(ScriptableObject)))
+            {
+                _so = ScriptableObject.CreateInstance(type);
+            }
+            else
+            {
+                Debug.LogError($"Unhandled sketch fixture type '{type}'.");
+            }
+        }
+
+        public void OnDestroy()
+        {
+            AttemptToInvokeMethod(_so);
+            
+            if (_monobeh != null)
+                Destroy(_monobeh);
+            if (_so != null)
+                Destroy(_so);
+        }
+
+        public void Start() => AttemptToInvokeMethod(_so);
+        public void Update() => AttemptToInvokeMethod(_so);
+        public void FixedUpdate() => AttemptToInvokeMethod(_so);
+        public void LateUpdate() => AttemptToInvokeMethod(_so);
+        public void OnGUI() => AttemptToInvokeMethod(_so);
+        public void OnDrawGizmos() => AttemptToInvokeMethod(_so);
+        public void OnDrawGizmosSelected() => AttemptToInvokeMethod(_so);
+
+        private void AttemptToInvokeMethod(object obj, [CallerMemberName] string callerName = "")
+        {
+            // No, it cannot be simplified as UnityEngine.Object is a comparison overload.
+            if (obj != null)
+            {
+                obj.GetType().GetMethod(callerName)?.Invoke(obj, null);
+            }
+        }
+    }
+}

--- a/Runtime/SketchFixtureRunner.cs.meta
+++ b/Runtime/SketchFixtureRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36603585f99d6634aacfa60f0d18e08e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>'
 e.g. 27_header-styles into main: Update Header colours to match style guide -->
## Summary
<!-- A clear and concise summary (1-2 sentences) of changes made. -->
Sketches can now inherit from ScriptableObjects, which lets you put their asm in editor only. You cannot define MonoBehaviours in an EditorOnly asm.

## Closes
<!-- Add task issue links to close here, e.g. #123 
There should always be at least one of these. -->
closes #8 

## Details
<!-- A more in-depth listing of changes made. If none, remove this section. 
This section is to aid the reviewer by increasing their understanding of what was done here. -->
The added SketchFixtureRunner deals with invoking the correct Unity Messages on the ScriptableObject.