### PR TITLE
Merge 18 to Develop: Make Flume optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Sketch window now uses Name, not FullyQualifiedName.
+- Flume is now an optional dependency; adding additional function, but not required.
 
 ### Fixed
 

--- a/Editor/AIR.Sketch.Editor.asmdef
+++ b/Editor/AIR.Sketch.Editor.asmdef
@@ -2,8 +2,8 @@
     "name": "AIR.Sketch.Editor",
     "rootNamespace": "",
     "references": [
-        "AIR.Flume",
-        "AIR.Sketch.Runtime"
+        "AIR.Sketch.Runtime",
+        "AIR.Flume"
     ],
     "includePlatforms": [],
     "excludePlatforms": [
@@ -27,6 +27,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.air.flume",
+            "expression": "0.0.1",
+            "define": "USE_FLUME"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Editor/SketchRunner.cs
+++ b/Editor/SketchRunner.cs
@@ -43,7 +43,9 @@ namespace AIR.Sketch
                     var asm = assemblies.First(a => a.FullName == asmName);
                     var sketchType = asm.GetType(fullTypeName);
                     var sketchGo = new GameObject(sketchType.Name);
+#if USE_FLUME
                     sketchGo.AddComponent<SketchServiceInstaller>();
+#endif
                     var fixtureRunner = sketchGo.AddComponent<SketchFixtureRunner>();
                     fixtureRunner.RunSketchFixture(sketchType);
                 }

--- a/Editor/SketchServiceInstaller.cs
+++ b/Editor/SketchServiceInstaller.cs
@@ -1,3 +1,4 @@
+#if USE_FLUME
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -89,3 +90,4 @@ namespace AIR.Sketch
         }
     }
 }
+#endif

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# AIR.Sketch
+# Sketch
 A Sketch Framework for the Unity Editor.
 
 ## Description
-AIR's sketch framework allows you to build and interactively run small code snippets (called "Sketches") in isolation, without needing to build them into a game or scene. Often, the best way to build new features are in isolation, and this framework facilitates that. Features built as sketches can be easily found, demonstrated and worked on, and much like tests, these sketches can then also serve as reference for certain feature working in isolation.
+Actuators's sketch framework allows you to build and interactively run small code snippets (called "Sketches") in isolation, without needing to build them into a game or scene.
+
+Often, the best way to build new features are in isolation, and this framework facilitates that. Features built as sketches can be easily found, demonstrated and worked on, and much like tests, these sketches can then also serve as reference for certain features working in isolation.
 
 ## Creating Sketches
 
@@ -23,8 +25,15 @@ Sketches inherit from UnityEngine.Object so that you can assign default editor v
 ### Adding Descriptions
 It is recommended that when creating a new sketch, you use the `[SketchDescription]` attribute on the class. Doing so provides developers more information about what the sketch is expected to demonstrate, and the text appears along with the test in in the sketch runner.
 
-### Dependencies
-The Sketch runner is coupled with [AIR.Flume](https://github.com/AnImaginedReality/Flume), which can provide sketches with dependency injection. If your sketch has a Dependency, add the `[SketchDependsOn(Type serviceType, Type serviceImplementation)]` attribute. By adding this attribute along with the given dependency type and implementation type, AIR.Sketch will create the necessary dependencies for your sketch to run. Note that dependencies don't have to be a sketch's direct dependency. A dependency will be injected for **any** object instantiated in the sketch.
+## Integrations
+
+### Flume
+
+The Sketch runner has additional functionality if included in a project also using [Flume](https://github.com/ActuatorDigital/Flume), which can provide sketches with dependency injection.
+
+If your sketch has a Dependency, add the `[SketchDependsOn(Type serviceType, Type serviceImplementation)]` attribute.
+
+By adding this attribute along with the given dependency type and implementation type, Sketch will create the necessary dependencies for your sketch to run. Note that dependencies don't have to be a sketch's direct dependency. A dependency will be injected for **any** object instantiated in the sketch.
 
 ## Sketch Runner
 The sketch runner window can be found in the Unity Editor Window dropdown beside the test runner. To open the sketch runner, in the unity editor, navigate to:


### PR DESCRIPTION
## Summary
<!-- A clear and concise summary (1-2 sentences) of changes made. -->
Adds a version define and preprocessor conditionals so that Flume-referencing code only becomes available if Flume is also added to the package manager.
Effect is that Flume is now an optional dependency, meaning Sketch can be used on projects without Flume installed.

## Closes
<!-- Add task issue links to close here, e.g. #123 
There should always be at least one of these. -->
closes #18 

## Details
<!-- A more in-depth listing of changes made. If none, remove this section. 
This section is to aid the reviewer by increasing their understanding of what was done here. -->
- Version define added to Sketch.Editor asmdef, allowing preprocessor define usage
- Flume-using code wrapped in preprocessor define condition
- Sketch automatically enables Flume code if and only if Flume added to project as well.

## Screenshots
<!-- If applicable, add screenshots to help explain changes made.  If none, remove this section. -->
![image](https://user-images.githubusercontent.com/60564759/228389196-43c03d48-6941-4580-8341-30c4e2496360.png)
