### PR TITLE
Merge  feature/28_assembly-csharp-support into main: Drop .Sketch assembly requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## [0.1.0]
 
+### Added
+- Introduced `SketchDependsOverrideAttribute`, allowing for more specific dependency injection for subclasses of sketches. This provides greater flexibility when extending abstract sketches.
+
 ### Changed
 
 - Changed the top level namespace (This is a breaking change). Please update your imports accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced `SketchDependsOverrideAttribute`, allowing for more specific dependency injection for subclasses of sketches. This provides greater flexibility when extending abstract sketches.
 - Removed the requirement for the ".Sketches" assembly naming convention. Users can now create and run sketches without adhering to this convention, allowing for more flexibility in less structured projects.
 
+### Changed
+- While it was previously required that the sketch class exists inside of an assembly with a name ending in ".Sketches", this requirement has been removed to accommodate less structured projects. However, maintaining a clear structure in your project is still recommended when possible.
+
 ## [0.1.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.1.0]
+
+## [0.1.1]
 
 ### Added
 - Introduced `SketchDependsOverrideAttribute`, allowing for more specific dependency injection for subclasses of sketches. This provides greater flexibility when extending abstract sketches.
+- Removed the requirement for the ".Sketches" assembly naming convention. Users can now create and run sketches without adhering to this convention, allowing for more flexibility in less structured projects.
+
+## [0.1.0]
 
 ### Changed
 

--- a/Editor/SketchDependsOverrideAttribute.cs
+++ b/Editor/SketchDependsOverrideAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Actuator.Sketch
+{
+    public class SketchDependsOverrideAttribute : SketchDependsOnAttribute
+    {
+        public SketchDependsOverrideAttribute(Type serviceType, Type serviceImplementation)
+            : base(serviceType, serviceImplementation) { }
+    }
+}

--- a/Editor/SketchDependsOverrideAttribute.cs.meta
+++ b/Editor/SketchDependsOverrideAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 204d52242be04da9bb75e1d3a4ff0a67
+timeCreated: 1622038352

--- a/Editor/SketchRunnerWindow.cs
+++ b/Editor/SketchRunnerWindow.cs
@@ -93,7 +93,8 @@ namespace Actuator.Sketch
             var filteredSketches = _sketches
                 .SelectMany(x => x.Fixtures)
                 .Where(x => x.FullName?.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
-                            x.Description?.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >= 0);
+                            x.Description?.IndexOf(actualSearchString, StringComparison.InvariantCultureIgnoreCase) >=
+                            0);
 
             _scrollPosition = GUILayout.BeginScrollView(_scrollPosition);
             GUILayout.BeginVertical(EditorStyles.helpBox);
@@ -227,16 +228,16 @@ namespace Actuator.Sketch
         private void Awake()
         {
             var playIconPath = "Packages/com.actuator.sketch/Editor/PlayIcon.png";
-            _playIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(playIconPath, typeof(Texture2D));
+            _playIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(playIconPath, typeof(Texture2D));
 
             var editIconPath = "Packages/com.actuator.sketch/Editor/EditIcon.png";
-            _editIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(editIconPath, typeof(Texture2D));
+            _editIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(editIconPath, typeof(Texture2D));
 
             var unpinnedIconPath = "Packages/com.actuator.sketch/Editor/UnpinnedIcon.png";
-            _unpinnedIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(unpinnedIconPath, typeof(Texture2D));
+            _unpinnedIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(unpinnedIconPath, typeof(Texture2D));
 
             var pinnedIconPath = "Packages/com.actuator.sketch/Editor/PinnedIcon.png";
-            _pinnedIcon = (Texture2D)AssetDatabase.LoadAssetAtPath(pinnedIconPath, typeof(Texture2D));
+            _pinnedIcon = (Texture2D) AssetDatabase.LoadAssetAtPath(pinnedIconPath, typeof(Texture2D));
 
             RefreshSketchList();
         }
@@ -251,17 +252,17 @@ namespace Actuator.Sketch
         {
             _sketches.Clear();
             var locator = new SketchAssetLocator();
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
-
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
                 var fixtures = new List<SketchFixture>();
                 foreach (var type in assembly.GetTypes())
                 {
                     if (type.IsAbstract) continue;
-                    var sketchFixtureAttribute = (SketchFixtureAttribute)Attribute
+                    var sketchFixtureAttribute = (SketchFixtureAttribute) Attribute
                         .GetCustomAttribute(type, typeof(SketchFixtureAttribute));
                     if (sketchFixtureAttribute == null) continue;
 
-                    var descriptionAttribute = (SketchDescriptionAttribute)Attribute
+                    var descriptionAttribute = (SketchDescriptionAttribute) Attribute
                         .GetCustomAttribute(type, typeof(SketchDescriptionAttribute));
                     var description = descriptionAttribute?.Description;
 
@@ -276,7 +277,7 @@ namespace Actuator.Sketch
                     fixtures.Add(sketchFixture);
                 }
 
-                if(fixtures.Any())
+                if (fixtures.Any())
                     _sketches.Add(new SketchAssembly(assembly.GetName().Name, fixtures.ToArray()));
             }
         }

--- a/Editor/SketchRunnerWindow.cs
+++ b/Editor/SketchRunnerWindow.cs
@@ -251,10 +251,8 @@ namespace Actuator.Sketch
         {
             _sketches.Clear();
             var locator = new SketchAssetLocator();
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                var assemblyName = assembly.GetName().Name;
-                if (!assemblyName.EndsWith(".Sketches")) continue;
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
+
                 var fixtures = new List<SketchFixture>();
                 foreach (var type in assembly.GetTypes())
                 {
@@ -278,7 +276,8 @@ namespace Actuator.Sketch
                     fixtures.Add(sketchFixture);
                 }
 
-                _sketches.Add(new SketchAssembly(assembly.GetName().Name, fixtures.ToArray()));
+                if(fixtures.Any())
+                    _sketches.Add(new SketchAssembly(assembly.GetName().Name, fixtures.ToArray()));
             }
         }
 

--- a/Editor/SketchServiceInstaller.cs
+++ b/Editor/SketchServiceInstaller.cs
@@ -69,13 +69,27 @@ namespace Actuator.Sketch
             var components = GetComponents<MonoBehaviour>();
             foreach (var component in components)
             {
-                var dependsOnAttributes = (SketchDependsOnAttribute[])component.GetType()
-                    .GetCustomAttributes(typeof(SketchDependsOnAttribute), true);
+                var dependsOnAttributes = component.GetType()
+                    .GetCustomAttributes(typeof(SketchDependsOnAttribute), true)
+                    .Cast<SketchDependsOnAttribute>()
+                    .ToList();
+
+                var sketchDependencyOverrideAttributes = (SketchDependsOverrideAttribute[]) component.GetType()
+                    .GetCustomAttributes(typeof(SketchDependsOverrideAttribute), true);
+                foreach (var dependencyOverride in sketchDependencyOverrideAttributes)
+                {
+                    dependsOnAttributes.Remove(dependencyOverride);
+                    var dependsOnToOverride = dependsOnAttributes
+                        .FirstOrDefault(d => d.ServiceType == dependencyOverride.ServiceType);
+                    dependsOnAttributes.Remove(dependsOnToOverride);
+                    dependsOnAttributes.Add(dependencyOverride);
+                }
 
                 var sketchHasDependency = dependsOnAttributes.Any();
                 if (sketchHasDependency)
                 {
-                    var dependencies = ActivateDependencies(dependsOnAttributes);
+                    var sketchDependsOnArr = dependsOnAttributes.ToArray();
+                    var dependencies = ActivateDependencies(sketchDependsOnArr);
                     activatedDependencies.AddRange(dependencies);
                 }
             }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ As of version 0.1.0, we've made a significant update to our framework - the top-
 For the Unity Editor to recognise and run sketches, they must:
 1. The sketch class must have the `[SketchFixture]` attribute.
 2. Inherit from MonoBehaviour or ScriptableObject.
-3. **(Updated in version 0.1.0)** While it was previously required that the sketch class exists inside of an assembly with a name ending in ".Sketches", this requirement has been removed to accommodate less structured projects. However, maintaining a clear structure in your project is still recommended when possible.
 
 ### Running
 
@@ -41,7 +40,7 @@ By adding this attribute along with the given dependency type and implementation
 
 #### Overriding Dependencies
 
-From version 0.1.0 onwards, users can add more specific dependency injection for subclasses of sketches, providing greater flexibility when extending abstract sketches. This is done using the new `SketchDependsOverrideAttribute`.
+From version 0.1.1 onwards, users can add more specific dependency injection for subclasses of sketches, providing greater flexibility when extending abstract sketches. This is done using the new `SketchDependsOverrideAttribute`.
 
 This feature might be particularly useful if you're using Flume with many sketches with shared behaviour, where varied behaviour from inherited or abstract sketches is desired.
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ As of version 0.1.0, we've made a significant update to our framework - the top-
 
 ### Prerequisites
 For the Unity Editor to recognise and run sketches, they must:
-1. The sketch class must exists inside of an assembly with a name ending in ".Sketches". eg `Example.Sketches.asmdef`.
-2. The sketch class must have the `[SketchFixture]` attribute.
-3. Inherit from MonoBehaviour or ScriptableObject.
-4. **(New in version 0.1.0)** The sketch class should be in the updated top-level namespace.
+1. The sketch class must have the `[SketchFixture]` attribute.
+2. Inherit from MonoBehaviour or ScriptableObject.
+3. **(Updated in version 0.1.0)** While it was previously required that the sketch class exists inside of an assembly with a name ending in ".Sketches", this requirement has been removed to accommodate less structured projects. However, maintaining a clear structure in your project is still recommended when possible.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ If your sketch has a Dependency, add the `[SketchDependsOn(Type serviceType, Typ
 
 By adding this attribute along with the given dependency type and implementation type, Sketch will create the necessary dependencies for your sketch to run. Note that dependencies don't have to be a sketch's direct dependency. A dependency will be injected for **any** object instantiated in the sketch.
 
+#### Overriding Dependencies
+
+From version 0.1.0 onwards, users can add more specific dependency injection for subclasses of sketches, providing greater flexibility when extending abstract sketches. This is done using the new `SketchDependsOverrideAttribute`.
+
+This feature might be particularly useful if you're using Flume with many sketches with shared behaviour, where varied behaviour from inherited or abstract sketches is desired.
+
 ## Sketch Runner
 The sketch runner window can be found in the Unity Editor Window dropdown beside the test runner. To open the sketch runner, in the unity editor, navigate to:
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.actuator.sketch",
   "displayName": "Sketch Framework",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Sketch Framework for the Unity Editor.",
   "author": "Actuator Digital",
   "type": "library",


### PR DESCRIPTION
<!-- title as ''
 e.g. 27_header-styles into main: Update Header colours to match style guide -->
## Summary
This pull request updates the prerequisites for sketch classes and introduces more flexible dependency injection for subclasses of sketches.

## Closes
<!-- Add task issue links to close here, e.g. #123 
There should always be at least one of these. -->
closes #27 #28

## Details
The changes made include:
1. Removed the prerequisite for the sketch class to exist inside of an assembly with a name ending in ".Sketches". Instead, users are recommended to maintain a clear structure in their projects when possible.
2. Introduced `SketchDependsOverrideAttribute`, a new attribute for more specific dependency injection for subclasses of sketches, which provides greater flexibility when extending abstract sketches.
3. The performance of identifying sketches will be reduced, as all the assemblies must now be searched. 

## Screenshots
N/A

## Additional Context
These changes should increase the flexibility and adaptability of sketch classes, especially in less structured projects. Additionally, the ability to override dependencies in subclasses of sketches should be useful when implementing shared behavior across sketches with varied behavior from inherited or abstract sketches.

## Project Health
- [x] Readme updated.
- [x] Changelog updated.
- [ ] Temp / cache added to gitignore.
- [x] UnitTests run and passed.
- [ ] Replaced assets have been removed.
- [ ] Updated dependencies have been noted. <!-- E.G. a package version, a tool version, unity, runtime, etc. -->
- [x] Code coverage run and is acceptable.
- [ ] Large files tracked with LFS.
- [X] Project performance degredation explained.
