### PR TITLE
Merge 32 into main: Handle typo change 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle Unity Gui Skin typo change from "ToolbarSeachCancelButton" to "ToolbarSearchCancelButton".
+
 ## [0.1.1]
 
 ### Added

--- a/Editor/SketchRunnerWindow.cs
+++ b/Editor/SketchRunnerWindow.cs
@@ -76,7 +76,11 @@ namespace Actuator.Sketch
             const string FilterSearchTextControlName = "SketchFilterSearchBoxName";
             GUI.SetNextControlName(FilterSearchTextControlName);
             _searchString = GUILayout.TextField(_searchString, EditorStyles.toolbarSearchField);
+#if UNITY_2022_3_OR_NEWER
+            if (GUILayout.Button("", GUI.skin.FindStyle("ToolbarSearchCancelButton")))
+#else
             if (GUILayout.Button("", GUI.skin.FindStyle("ToolbarSeachCancelButton")))
+#endif
             {
                 // Remove focus if cleared
                 _searchString = string.Empty;


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>'
 e.g. 27_header-styles into main: Update Header colours to match style guide -->
## Summary
<!-- A clear and concise summary of changes made. 1-2 sentences. -->
Unity fixed a typo in a gui skin name, so now we have to deal with the old typo and the new non-typo.

More details here https://forum.unity.com/threads/addressablesgroupwindow-missing-styles-in-2022-3-1.1445899/

## Closes
<!-- Add task issue links to close here, e.g. #123 
There should always be at least one of these. -->
closes #32 

## Project Health
<!-- This section is especially important when merging to main or similar. 
All relevant items that are not ticked should be addressed in either the Details or Additional context section.
Remove any lines that do not apply. -->
- [x] Changelog updated.